### PR TITLE
feat(nx-cloud): set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -31,5 +31,6 @@
     "build": { "outputs": ["{projectRoot}/dist"], "cache": true },
     "e2e": { "cache": true }
   },
-  "nxCloudAccessToken": "YTI2Mzg0ZmYtMmRlYy00MmQxLTk4NjQtNjdjZWEyMDNjOGY5fHJlYWQtd3JpdGU="
+  "nxCloudAccessToken": "YTI2Mzg0ZmYtMmRlYy00MmQxLTk4NjQtNjdjZWEyMDNjOGY5fHJlYWQtd3JpdGU=",
+  "nxCloudId": "6688147cc9aa3f7c50339ded"
 }

--- a/nx.json
+++ b/nx.json
@@ -32,6 +32,6 @@
     "e2e": { "cache": true }
   },
   "nxCloudAccessToken": "YTI2Mzg0ZmYtMmRlYy00MmQxLTk4NjQtNjdjZWEyMDNjOGY5fHJlYWQtd3JpdGU=",
-  "nxCloudId": "6750a63c7a804b8dbbfad606",
+  "nxCloudId": "6750a6c74a945124daf37315",
   "nxCloudUrl": "https://staging.nx.app"
 }

--- a/nx.json
+++ b/nx.json
@@ -2,12 +2,7 @@
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
   "defaultBase": "main",
   "plugins": [
-    {
-      "plugin": "@nx/eslint/plugin",
-      "options": {
-        "targetName": "lint"
-      }
-    },
+    { "plugin": "@nx/eslint/plugin", "options": { "targetName": "lint" } },
     {
       "plugin": "@nx/vite/plugin",
       "options": {
@@ -29,18 +24,12 @@
     },
     {
       "plugin": "@nx/playwright/plugin",
-      "options": {
-        "targetName": "playwright:e2e"
-      }
+      "options": { "targetName": "playwright:e2e" }
     }
   ],
   "targetDefaults": {
-    "build": {
-      "outputs": ["{projectRoot}/dist"],
-      "cache": true
-    },
-    "e2e": {
-      "cache": true
-    }
-  }
+    "build": { "outputs": ["{projectRoot}/dist"], "cache": true },
+    "e2e": { "cache": true }
+  },
+  "nxCloudAccessToken": "YTI2Mzg0ZmYtMmRlYy00MmQxLTk4NjQtNjdjZWEyMDNjOGY5fHJlYWQtd3JpdGU="
 }

--- a/nx.json
+++ b/nx.json
@@ -32,5 +32,6 @@
     "e2e": { "cache": true }
   },
   "nxCloudAccessToken": "YTI2Mzg0ZmYtMmRlYy00MmQxLTk4NjQtNjdjZWEyMDNjOGY5fHJlYWQtd3JpdGU=",
-  "nxCloudId": "6688147cc9aa3f7c50339ded"
+  "nxCloudId": "67224f91860bded5659c95ef",
+  "nxCloudUrl": "https://staging.nx.app"
 }

--- a/nx.json
+++ b/nx.json
@@ -32,6 +32,6 @@
     "e2e": { "cache": true }
   },
   "nxCloudAccessToken": "YTI2Mzg0ZmYtMmRlYy00MmQxLTk4NjQtNjdjZWEyMDNjOGY5fHJlYWQtd3JpdGU=",
-  "nxCloudId": "67224f91860bded5659c95ef",
+  "nxCloudId": "6750a63c7a804b8dbbfad606",
   "nxCloudUrl": "https://staging.nx.app"
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace 
    
This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to 
https://cloud.nx.app/orgs/6750a6be7a804b8dbbfad60e/workspaces/6750a6c74a945124daf37315

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.